### PR TITLE
upgrade to shed.css 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ember-cli-babel": "^6.3.0",
     "ember-cli-node-assets": "^0.2.2",
     "marked": "^0.3.6",
-    "shed-css": "^1.2.1"
+    "shed-css": "^1.3.0"
   },
   "devDependencies": {
     "bootstrap-sass": "^3.3.7",


### PR DESCRIPTION
adds support for `list-style-type`.

@romulomachado does this conflict with the work you're doing on the docs site or ok to merge and cut a release? 